### PR TITLE
Switch to forked gelfd2 gem for uncompressed support

### DIFF
--- a/fluent-plugin-input-gelf.gemspec
+++ b/fluent-plugin-input-gelf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency "fluentd"
-  gem.add_runtime_dependency "gelfd", ">= 0.2.0"
+  gem.add_runtime_dependency "gelfd2", ">= 0.3.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"

--- a/lib/fluent/plugin/in_gelf.rb
+++ b/lib/fluent/plugin/in_gelf.rb
@@ -13,7 +13,7 @@ module Fluent
     def initialize
       super
       require 'fluent/plugin/socket_util'
-      require 'gelfd'
+      require 'gelfd2'
     end
 
     desc "The value is the tag assigned to the generated events."
@@ -70,7 +70,7 @@ module Fluent
 
     def receive_data(data, addr)
       begin
-        msg = Gelfd::Parser.parse(data)
+        msg = Gelfd2::Parser.parse(data)
       rescue => e
         log.warn 'Gelfd failed to parse a message', error: e.to_s
         log.warn_backtrace

--- a/lib/fluent/plugin/in_gelf.rb
+++ b/lib/fluent/plugin/in_gelf.rb
@@ -89,7 +89,7 @@ module Fluent
         time = record.delete('timestamp').to_i if record.key?('timestamp')
 
         # Postprocess recorded event
-        strip_leading_underscore(record) if @strip_leading_underscore
+        strip_leading_underscore_(record) if @strip_leading_underscore
 
         emit(time, record)
       }
@@ -117,7 +117,7 @@ module Fluent
 
     private
 
-    def strip_leading_underscore(record)
+    def strip_leading_underscore_(record)
       record.keys.each { |k|
         next unless k[0,1] == '_'
         record[k[1..-1]] = record.delete(k)


### PR DESCRIPTION
Currently the gelfd gem appears to have been abandoned and it has some bugs around uncompressed data lusis/gelfd#5 lusis/gelfd#4 so it has been forked into gelfd2.

This pull request switches this plugin to using that forked gem and fixes a warning that the plugin was redefining the method `strip_leading_underscore`.