### PR TITLE
Migrate to use v1 API

### DIFF
--- a/fluent-plugin-input-gelf.gemspec
+++ b/fluent-plugin-input-gelf.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
   gem.add_runtime_dependency "gelfd2", ">= 0.3.0"
 
   gem.add_development_dependency "bundler"

--- a/lib/fluent/plugin/in_gelf.rb
+++ b/lib/fluent/plugin/in_gelf.rb
@@ -4,6 +4,8 @@ require 'time'
 require 'cool.io'
 require 'yajl'
 
+require 'gelfd2'
+
 require 'fluent/plugin/input'
 
 module Fluent::Plugin
@@ -16,8 +18,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require 'fluent/plugin/socket_util'
-      require 'gelfd2'
     end
 
     desc "The value is the tag assigned to the generated events."

--- a/lib/fluent/plugin/in_gelf.rb
+++ b/lib/fluent/plugin/in_gelf.rb
@@ -37,7 +37,6 @@ module Fluent::Plugin
         raise Fluent::ConfigError, "gelf input protocol type should be 'tcp' or 'udp'"
       end
     end
-    config_param :blocking_timeout, :time, default: 0.5
     desc 'Strip leading underscore'
     config_param :strip_leading_underscore, :bool, default: true
 

--- a/lib/fluent/plugin/in_gelf.rb
+++ b/lib/fluent/plugin/in_gelf.rb
@@ -27,16 +27,7 @@ module Fluent::Plugin
     desc 'The bind address to listen to.'
     config_param :bind, :string, default: '0.0.0.0'
     desc 'The transport protocol used to receive logs.(udp, tcp)'
-    config_param :protocol_type, default: :udp do |val|
-      case val.downcase
-      when 'tcp'
-        :tcp
-      when 'udp'
-        :udp
-      else
-        raise Fluent::ConfigError, "gelf input protocol type should be 'tcp' or 'udp'"
-      end
-    end
+    config_param :protocol_type, :enum, list: [:udp, :tcp], default: :udp
     desc 'Strip leading underscore'
     config_param :strip_leading_underscore, :bool, default: true
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,16 +13,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'fluent/test'
-unless ENV.has_key?('VERBOSE')
-  nulllogger = Object.new
-  nulllogger.instance_eval {|obj|
-    def method_missing(method, *args)
-      # pass
-    end
-  }
-  $log = nulllogger
-end
-
+require 'fluent/test/driver/input'
 require 'fluent/plugin/in_gelf'
 
 def unused_port


### PR DESCRIPTION
* Use v1 Input API and Input test driver
* Use parser and compat_parameters plugin helper for common parser usage pattern
* Use server plugin helper for common Cool.io usage pattern
* Tweak for requiring files
* Use enum type instead of hand written value checking